### PR TITLE
fix: hulu & apple tv+ icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,7 +554,7 @@
                      class="h-6 md:h-8 w-auto grayscale hover:grayscale-0 hover:scale-110 hover:brightness-125 transition-all duration-300 transform hover:drop-shadow-[0_0_7px_rgba(116,80,254,0.7)]">
             </a>
             <a href="https://tv.apple.com" target="_blank" class="transform transition-transform hover:scale-105">
-                <img src="https://upload.wikimedia.org/wikipedia/commons/8/8a/Apple_TV_Plus_logo.svg" 
+                <img src="https://upload.wikimedia.org/wikipedia/commons/2/28/Apple_TV_Plus_Logo.svg" 
                      alt="Apple TV+" 
                      class="h-6 md:h-8 w-auto grayscale hover:grayscale-0 hover:scale-110 hover:brightness-125 transition-all duration-300 transform hover:drop-shadow-[0_0_7px_rgba(0,244,244,0.7)]">
             </a>

--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@
                      class="h-6 md:h-8 w-auto grayscale hover:grayscale-0 hover:scale-110 hover:brightness-125 transition-all duration-300 transform hover:drop-shadow-[0_0_7px_rgba(113,168,255,0.7)]">
             </a>
             <a href="https://www.hulu.com" target="_blank" class="transform transition-transform hover:scale-105">
-                <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/Hulu_logo_%282014%29.svg" 
+                <img src="https://upload.wikimedia.org/wikipedia/commons/f/f9/Hulu_logo_%282018%29.svg" 
                      alt="Hulu" 
                      class="h-6 md:h-8 w-auto grayscale hover:grayscale-0 hover:scale-110 hover:brightness-125 transition-all duration-300 transform hover:drop-shadow-[0_0_7px_rgba(28,231,131,0.7)]">
             </a>


### PR DESCRIPTION
The Hulu icon was updated in 2018 and the 2014 version no longer exists on upload.wikimedia.org