### PR TITLE
feat: fallback poster for home & watch page

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,7 +478,12 @@
                             <div class="relative h-full">
                                 <img :src="'https://image.tmdb.org/t/p/w500' + item.poster_path" 
                                      :alt="item.title || item.name"
-                                     class="w-full h-full object-cover">
+                                     class="w-full h-full object-cover"
+                                     @error="event => {
+                                            event.target.src = '/logo.png';
+                                            event.target.classList.remove('object-cover');
+                                            event.target.classList.add('object-contain');
+                                        }" />
                                 <div class="card-overlay absolute inset-0 flex flex-col justify-end p-2 sm:p-3 md:p-4">
                                     <h3 class="text-sm md:text-lg font-semibold" x-text="item.title || item.name"></h3>
                                     <p class="text-gray-400 text-xs md:text-sm mt-1" x-text="'⭐ ' + (item.vote_average || 'N/A') + '/10'"></p>

--- a/watch.html
+++ b/watch.html
@@ -718,9 +718,15 @@
                             <a :href="'watch.html?id=' + item.id + '&type=' + contentType"
                                class="block rounded-lg overflow-hidden bg-gray-800 aspect-[2/3]">
                                 <div class="relative h-full">
-                                    <img :src="'https://image.tmdb.org/t/p/w500' + item.poster_path"
-                                         :alt="item.title || item.name"
-                                         class="w-full h-full object-cover">
+                                    <img
+                                        :src="'https://image.tmdb.org/t/p/w500' + item.poster_path"
+                                        :alt="item.title || item.name"
+                                        class="w-full h-full object-cover transition-all flex items-center justify-center"
+                                        @error="event => {
+                                            event.target.src = '/logo.png';
+                                            event.target.classList.remove('object-cover');
+                                            event.target.classList.add('object-contain');
+                                        }" />
                                     <div class="card-overlay absolute inset-0 flex flex-col justify-end p-2 sm:p-3 md:p-4">
                                         <h3 class="text-sm md:text-base font-semibold" x-text="item.title || item.name"></h3>
                                         <p class="text-gray-400 text-xs md:text-sm flex items-center mt-1">


### PR DESCRIPTION
### Before:
![before](https://github.com/user-attachments/assets/aa9e30cb-4b9a-438c-a54d-d5879b9b8789)
### After:
![after](https://github.com/user-attachments/assets/71fad4d0-fce7-415f-8985-792f1ef4aa2f)
### Similarly on home page:
![home](https://github.com/user-attachments/assets/5215391f-6c29-4cbf-9173-39c981499a4c)

Check this url for actual issue where I found the image error: https://novastream.top/watch.html?id=348&type=movie