### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM nginx:alpine
-RUN rm -rf /usr/share/nginx/html/*
 COPY . /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Removed the RUN rm -rf /usr/share/nginx/html/* line since COPY will overwrite the existing content in /usr/share/nginx/html by default.