### PR TITLE
enhancement: add mappletv (4k provider)

### DIFF
--- a/sources.js
+++ b/sources.js
@@ -1,5 +1,14 @@
 const availableSources = [
     {
+        id: 'mapple',
+        name: 'MappleTv',
+        isFrench: false,
+        urls: {
+            movie: 'https://mappletv.uk/watch/movie/{id}',
+            tv: 'https://mappletv.uk/watch/tv/{id}-{season}-{episode}'
+        }
+    },
+    {
         id: 'pstream',
         name: 'P-Stream',
         isFrench: false,


### PR DESCRIPTION
This pull request adds a new streaming source to the list of available sources in `sources.js`. The new source, "MappleTv," includes support for both movies and TV shows.

New streaming source added:

* Added a new source object for "MappleTv" with movie and TV show URL templates to the `availableSources` array in `sources.js`.